### PR TITLE
fix: tsconfig error

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,8 @@
     "noUnusedLocals": true,
     "noImplicitAny": true,
     "allowJs": true,
+    "noEmit": true,
+    "outDir": "dist",
     "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
you may encouter the error like:

![image](https://user-images.githubusercontent.com/49113249/153757715-2f033094-fcd0-48b4-bedf-1f2849c05ee2.png)



### cause & solution

this error is for `tsc`, as we compiled by `ts-up` which is `esbuild`, so this won't effect project.
but error is always annoying, the cause in breif is:

- as `allowJS` enabled, you need to specify the `outDir` to avoid the output `.js` files are compiled again.

- also, if not using `tsc`, you need to set `noEmit` explicitly to let typescirpt just do type check (actually the [esbuld docs](https://esbuild.github.io/content-types/#typescript) has mentioned about that).


### conclusion:

- spiecify `outDir` make it excluded from `include`
- enable `noEmit` if you not using `tsc` do compilation
either above can solve this error



