### PR TITLE
Replace pnpx with pnpm dlx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: ['test']
+    needs: ["test"]
     if: "!contains(github.event.head_commit.message, 'skip-release') && !contains(github.event.head_commit.message, 'skip-ci') && github.event_name != 'pull_request'"
     steps:
       - uses: actions/checkout@v3
@@ -70,7 +70,7 @@ jobs:
             ${{ runner.os }}-
       - run: npm i -g pnpm
       - run: pnpm i
-      - run: pnpx semantic-release --branches main
+      - run: pnpm dlx semantic-release --branches main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
[`pnpx` is deprecated](https://pnpm.io/zh/6.x/pnpx-cli) in latest versions of pnpm, replaced with [`pnpm dlx` which stands for install and run](https://pnpm.io/cli/dlx).