### PR TITLE
ci(semantic-release): run semanticc-release on node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,13 +50,13 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: ['test']
+    needs: ["test"]
     if: "!contains(github.event.head_commit.message, 'skip-release') && !contains(github.event.head_commit.message, 'skip-ci') && github.event_name != 'pull_request'"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Cache ~/.pnpm-store
         uses: actions/cache@v2
         env:


### PR DESCRIPTION
The [latest version of `semantic-release`](https://github.com/semantic-release/semantic-release/releases/tag/v20.0.0) is requiring Node.js 18 now.